### PR TITLE
Activate Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+sudo: required
+dist: trusty
+python:
+  - "2.7"
+before_install:
+  - sudo apt-get -qq -y update
+  - sudo apt-get install -y --no-install-recommends zip
+install:
+  - pip install wrc
+script:
+  - git remote add cubing https://github.com/cubing/wca-regulations-translations
+  - git fetch cubing
+  - wget https://github.com/cubing/wca-regulations/archive/official.zip
+  - unzip official.zip
+  - ./travis.sh

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+RET=0
+for file in `git diff --name-only cubing/master`; do
+  if [[ $file == */wca-regulations.md || $file == */wca-guidelines.md ]]; then
+    echo "Detected change for file $file, running diff."
+    wrc $file --diff wca-regulations-official
+    RET=$(($RET+$?))
+  fi
+done
+
+LANGUAGES=`wrc-languages`
+echo "================================="
+mkdir "build"
+for l in $LANGUAGES; do
+  INPUTDIR=${l}
+  echo "Doing check for language "${l}
+  wrc --target=check $INPUTDIR
+  RET=$(($RET+$?))
+done
+echo "================================="
+exit $RET


### PR DESCRIPTION
This adds the travis file, and activate an overall check of the translations, as well as a diff-check of the modified translations against the official Regulations and Guidelines.

Right now the build is expected to fail, but I'll force the rebuild once #34 is merged and it should pass (so this PR is meant to be merged after #34).