### PR TITLE
Updating pdf link.

### DIFF
--- a/portuguese-brazilian/wca-regulations.md
+++ b/portuguese-brazilian/wca-regulations.md
@@ -20,7 +20,7 @@ O uso das palavras "precisa", "não precisa", "deve", "não deve" e "pode" está
 ### Informação na Internet
 Website da World Cube Association: [www.worldcubeassociation.org](http://www.worldcubeassociation.org/)
 Fonte original do Regulamento da WCA: [www.worldcubeassociation.org/regulations](http://www.worldcubeassociation.org/regulations/)
-Regulamento da WCA em [Formato PDF](https://www.worldcubeassociation.org/regulations/wca-regulations-and-guidelines.pdf)
+Regulamento da WCA em [Formato PDF](link:pdf)
 
 ### Código Fonte
 O desenvolvimento do Regulamento e Orientações da WCA é público no [GitHub](https://github.com/cubing/wca-documents).


### PR DESCRIPTION
I ran into this while building the translations in the website.
The links should be to the translation's pdf, luckily we have a special link for that.

CC @pedrosino for information.